### PR TITLE
Bump riot.im to latest upstream release 0.15.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:8-alpine
 
-ENV VERSION 0.13.4
+ENV VERSION 0.15.5
 ENV DEFAULT_HS_URL "https://matrix.org"
 ENV DEFAULT_IS_URL "https://vector.im"
 ENV BRAND "Riot"


### PR DESCRIPTION
I might as well contribute this bump since I've been playing with your riot container image.